### PR TITLE
Renamed references to Object -> Obj

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "predaddy/predaddy",
+    "name": "glow/predaddy",
     "description": "Common DDD classes and utilities",
     "license": "MIT",
     "keywords": ["ddd", "eventbus", "aggregate"],
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "precore/precore": "~1.9 || ^2.0",
+        "precore/precore": "~4.0",
         "doctrine/annotations": "~1.1",
         "doctrine/cache": "~1.0",
         "lf4php/lf4php": "~4.2",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "precore/precore": "~4.0",
+        "glow/precore": "~3.0",
         "doctrine/annotations": "~1.1",
         "doctrine/cache": "~1.0",
         "lf4php/lf4php": "~4.2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "glow/predaddy",
+    "name": "glowteam/predaddy",
     "description": "Common DDD classes and utilities",
     "license": "MIT",
     "keywords": ["ddd", "eventbus", "aggregate"],
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "glow/precore": "~3.0",
+        "glowteam/precore": "~3.0",
         "doctrine/annotations": "~1.1",
         "doctrine/cache": "~1.0",
         "lf4php/lf4php": "~4.2",

--- a/src/predaddy/commandhandling/AbstractCommandHandler.php
+++ b/src/predaddy/commandhandling/AbstractCommandHandler.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\commandhandling;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use predaddy\domain\Repository;
 
 /**
@@ -32,7 +32,7 @@ use predaddy\domain\Repository;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class AbstractCommandHandler extends Object
+abstract class AbstractCommandHandler extends Obj
 {
     /**
      * @var Repository

--- a/src/predaddy/domain/AbstractAggregateId.php
+++ b/src/predaddy/domain/AbstractAggregateId.php
@@ -2,7 +2,7 @@
 
 namespace predaddy\domain;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 
@@ -12,7 +12,7 @@ use precore\util\Objects;
  * @package predaddy\domain
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class AbstractAggregateId extends Object implements AggregateId
+abstract class AbstractAggregateId extends Obj implements AggregateId
 {
     final public function equals(ObjectInterface $object = null)
     {

--- a/src/predaddy/domain/AbstractAggregateRoot.php
+++ b/src/predaddy/domain/AbstractAggregateRoot.php
@@ -24,7 +24,7 @@
 namespace predaddy\domain;
 
 use precore\lang\IllegalStateException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 use precore\util\Preconditions;
@@ -45,7 +45,7 @@ use precore\util\Preconditions;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class AbstractAggregateRoot extends Object implements AggregateRoot
+abstract class AbstractAggregateRoot extends Obj implements AggregateRoot
 {
     /**
      * @var string

--- a/src/predaddy/domain/EventPublisher.php
+++ b/src/predaddy/domain/EventPublisher.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\domain;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use predaddy\messagehandling\MessageBus;
 use predaddy\messagehandling\util\NullMessageBus;
 
@@ -35,7 +35,7 @@ use predaddy\messagehandling\util\NullMessageBus;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class EventPublisher extends Object
+final class EventPublisher extends Obj
 {
     /**
      * @var EventPublisher

--- a/src/predaddy/domain/GenericAggregateId.php
+++ b/src/predaddy/domain/GenericAggregateId.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\domain;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 
@@ -32,7 +32,7 @@ use precore\util\Objects;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class GenericAggregateId extends Object implements AggregateId
+final class GenericAggregateId extends Obj implements AggregateId
 {
     /**
      * @var string

--- a/src/predaddy/domain/NullAggregateId.php
+++ b/src/predaddy/domain/NullAggregateId.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\domain;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\util\Objects;
 
 /**
@@ -32,7 +32,7 @@ use precore\util\Objects;
  * @see predaddy\domain\AbstractDomainEvent
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class NullAggregateId extends Object implements AggregateId
+final class NullAggregateId extends Obj implements AggregateId
 {
     private static $instance;
 

--- a/src/predaddy/domain/eventsourcing/AbstractSnapshotEventStore.php
+++ b/src/predaddy/domain/eventsourcing/AbstractSnapshotEventStore.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\domain\eventsourcing;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectClass;
 use predaddy\domain\AggregateId;
 use predaddy\domain\DomainEvent;
@@ -31,7 +31,7 @@ use predaddy\domain\DomainEvent;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class AbstractSnapshotEventStore extends Object implements SnapshotEventStore
+abstract class AbstractSnapshotEventStore extends Obj implements SnapshotEventStore
 {
     /**
      * @var SnapshotStrategy

--- a/src/predaddy/domain/eventsourcing/EventSourcingRepository.php
+++ b/src/predaddy/domain/eventsourcing/EventSourcingRepository.php
@@ -24,7 +24,7 @@
 namespace predaddy\domain\eventsourcing;
 
 use InvalidArgumentException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectClass;
 use precore\util\Preconditions;
 use predaddy\domain\AggregateId;
@@ -37,7 +37,7 @@ use predaddy\domain\Repository;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class EventSourcingRepository extends Object implements Repository
+class EventSourcingRepository extends Obj implements Repository
 {
     /**
      * @var EventStore

--- a/src/predaddy/inmemory/InMemoryRepository.php
+++ b/src/predaddy/inmemory/InMemoryRepository.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\inmemory;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\util\Preconditions;
 use predaddy\domain\AggregateId;
 use predaddy\domain\AggregateRoot;
@@ -32,7 +32,7 @@ use predaddy\domain\Repository;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class InMemoryRepository extends Object implements Repository
+final class InMemoryRepository extends Obj implements Repository
 {
     /**
      * @var array

--- a/src/predaddy/messagehandling/AbstractMessage.php
+++ b/src/predaddy/messagehandling/AbstractMessage.php
@@ -25,7 +25,7 @@ namespace predaddy\messagehandling;
 
 use DateTime;
 use precore\lang\NullPointerException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 use precore\util\Preconditions;
@@ -36,7 +36,7 @@ use precore\util\UUID;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class AbstractMessage extends Object implements Message
+abstract class AbstractMessage extends Obj implements Message
 {
     protected $id;
     protected $created;

--- a/src/predaddy/messagehandling/ClosureWrapper.php
+++ b/src/predaddy/messagehandling/ClosureWrapper.php
@@ -24,11 +24,11 @@
 namespace predaddy\messagehandling;
 
 use Closure;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use ReflectionFunction;
 
-final class ClosureWrapper extends Object implements CallableWrapper
+final class ClosureWrapper extends Obj implements CallableWrapper
 {
     /**
      * @var Closure

--- a/src/predaddy/messagehandling/DefaultFunctionDescriptor.php
+++ b/src/predaddy/messagehandling/DefaultFunctionDescriptor.php
@@ -25,7 +25,7 @@ namespace predaddy\messagehandling;
 
 use precore\lang\ClassCastException;
 use precore\lang\NullPointerException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectClass;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
@@ -40,7 +40,7 @@ use ReflectionClass;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class DefaultFunctionDescriptor extends Object implements FunctionDescriptor
+class DefaultFunctionDescriptor extends Obj implements FunctionDescriptor
 {
     /**
      * @var string

--- a/src/predaddy/messagehandling/InterceptableMessageBus.php
+++ b/src/predaddy/messagehandling/InterceptableMessageBus.php
@@ -26,7 +26,7 @@ namespace predaddy\messagehandling;
 use ArrayIterator;
 use Closure;
 use InvalidArgumentException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\util\Preconditions;
 use predaddy\messagehandling\util\MessageCallbackClosures;
 use RuntimeException;
@@ -34,7 +34,7 @@ use RuntimeException;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class InterceptableMessageBus extends Object implements MessageBus
+abstract class InterceptableMessageBus extends Obj implements MessageBus
 {
     /**
      * @var MessageCallback

--- a/src/predaddy/messagehandling/MethodWrapper.php
+++ b/src/predaddy/messagehandling/MethodWrapper.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\messagehandling;
 
-use precore\lang\Objt;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 use ReflectionMethod;

--- a/src/predaddy/messagehandling/MethodWrapper.php
+++ b/src/predaddy/messagehandling/MethodWrapper.php
@@ -23,12 +23,12 @@
 
 namespace predaddy\messagehandling;
 
-use precore\lang\Object;
+use precore\lang\Objt;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 use ReflectionMethod;
 
-final class MethodWrapper extends Object implements CallableWrapper
+final class MethodWrapper extends Obj implements CallableWrapper
 {
     /**
      * @var object

--- a/src/predaddy/messagehandling/SubscriberExceptionContext.php
+++ b/src/predaddy/messagehandling/SubscriberExceptionContext.php
@@ -23,13 +23,13 @@
 
 namespace predaddy\messagehandling;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\util\Objects;
 
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class SubscriberExceptionContext extends Object
+final class SubscriberExceptionContext extends Obj
 {
     private $messageBus;
     private $message;

--- a/src/predaddy/messagehandling/interceptors/BlockerInterceptor.php
+++ b/src/predaddy/messagehandling/interceptors/BlockerInterceptor.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\messagehandling\interceptors;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use predaddy\messagehandling\DispatchInterceptor;
 use predaddy\messagehandling\InterceptorChain;
 use predaddy\messagehandling\NonBlockable;
@@ -40,7 +40,7 @@ use predaddy\messagehandling\NonBlockable;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class BlockerInterceptor extends Object implements DispatchInterceptor
+final class BlockerInterceptor extends Obj implements DispatchInterceptor
 {
     private $blocking = false;
 

--- a/src/predaddy/messagehandling/interceptors/BlockerInterceptorManager.php
+++ b/src/predaddy/messagehandling/interceptors/BlockerInterceptorManager.php
@@ -24,7 +24,7 @@
 namespace predaddy\messagehandling\interceptors;
 
 use Exception;
-use precore\lang\Object;
+use precore\lang\Obj;
 use predaddy\messagehandling\DispatchInterceptor;
 use predaddy\messagehandling\InterceptorChain;
 use predaddy\messagehandling\SubscriberExceptionContext;
@@ -33,7 +33,7 @@ use predaddy\messagehandling\SubscriberExceptionHandler;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class BlockerInterceptorManager extends Object implements DispatchInterceptor, SubscriberExceptionHandler
+final class BlockerInterceptorManager extends Obj implements DispatchInterceptor, SubscriberExceptionHandler
 {
     /**
      * @var BlockerInterceptor

--- a/src/predaddy/messagehandling/interceptors/EventPersister.php
+++ b/src/predaddy/messagehandling/interceptors/EventPersister.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\messagehandling\interceptors;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectClass;
 use predaddy\domain\EventStore;
 use predaddy\messagehandling\DispatchInterceptor;
@@ -32,7 +32,7 @@ use predaddy\messagehandling\InterceptorChain;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class EventPersister extends Object implements DispatchInterceptor
+final class EventPersister extends Obj implements DispatchInterceptor
 {
     /**
      * @var EventStore

--- a/src/predaddy/messagehandling/interceptors/WrapInTransactionInterceptor.php
+++ b/src/predaddy/messagehandling/interceptors/WrapInTransactionInterceptor.php
@@ -25,7 +25,7 @@ namespace predaddy\messagehandling\interceptors;
 
 use Exception;
 use lf4php\MDC;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\util\UUID;
 use predaddy\messagehandling\DispatchInterceptor;
 use predaddy\messagehandling\InterceptorChain;
@@ -41,7 +41,7 @@ use trf4php\TransactionManager;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class WrapInTransactionInterceptor extends Object implements DispatchInterceptor, SubscriberExceptionHandler
+final class WrapInTransactionInterceptor extends Obj implements DispatchInterceptor, SubscriberExceptionHandler
 {
     const MDC_KEY = 'TR';
 

--- a/src/predaddy/messagehandling/util/MessageCallbackClosures.php
+++ b/src/predaddy/messagehandling/util/MessageCallbackClosures.php
@@ -25,7 +25,7 @@ namespace predaddy\messagehandling\util;
 
 use Closure;
 use Exception;
-use precore\lang\Object;
+use precore\lang\Obj;
 use predaddy\messagehandling\MessageCallback;
 
 /**
@@ -42,7 +42,7 @@ use predaddy\messagehandling\MessageCallback;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class MessageCallbackClosures extends Object implements MessageCallback
+final class MessageCallbackClosures extends Obj implements MessageCallback
 {
     /**
      * @var Closure|null

--- a/src/predaddy/messagehandling/util/NullMessageBus.php
+++ b/src/predaddy/messagehandling/util/NullMessageBus.php
@@ -24,7 +24,7 @@
 namespace predaddy\messagehandling\util;
 
 use Closure;
-use precore\lang\Object;
+use precore\lang\Obj;
 use predaddy\messagehandling\MessageBus;
 use predaddy\messagehandling\MessageCallback;
 
@@ -32,7 +32,7 @@ use predaddy\messagehandling\MessageCallback;
  * @author Janos Szurovecz <szjani@szjani.hu>
  * @codeCoverageIgnore
  */
-final class NullMessageBus extends Object implements MessageBus
+final class NullMessageBus extends Obj implements MessageBus
 {
     /**
      * Post a message on this bus. It is dispatched to all subscribed handlers.

--- a/src/predaddy/presentation/Order.php
+++ b/src/predaddy/presentation/Order.php
@@ -23,7 +23,7 @@
 
 namespace predaddy\presentation;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 
@@ -32,7 +32,7 @@ use precore\util\Objects;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class Order extends Object
+class Order extends Obj
 {
     /**
      * @var Direction

--- a/src/predaddy/presentation/PageImpl.php
+++ b/src/predaddy/presentation/PageImpl.php
@@ -25,7 +25,7 @@ namespace predaddy\presentation;
 
 use ArrayIterator;
 use IteratorAggregate;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 
@@ -34,7 +34,7 @@ use precore\util\Objects;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class PageImpl extends Object implements IteratorAggregate, Page
+class PageImpl extends Obj implements IteratorAggregate, Page
 {
     private $content = [];
 

--- a/src/predaddy/presentation/PageRequest.php
+++ b/src/predaddy/presentation/PageRequest.php
@@ -24,7 +24,7 @@
 namespace predaddy\presentation;
 
 use InvalidArgumentException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 use precore\util\Preconditions;
@@ -35,7 +35,7 @@ use precore\util\Preconditions;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class PageRequest extends Object implements Pageable
+class PageRequest extends Obj implements Pageable
 {
     private $page;
     private $size;

--- a/src/predaddy/presentation/Sort.php
+++ b/src/predaddy/presentation/Sort.php
@@ -26,7 +26,7 @@ namespace predaddy\presentation;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use precore\util\Objects;
 
@@ -36,7 +36,7 @@ use precore\util\Objects;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class Sort extends Object implements IteratorAggregate, Countable
+class Sort extends Obj implements IteratorAggregate, Countable
 {
     private $orders = [];
 


### PR DESCRIPTION
This should bring `predaddy` back inline with `precore` once https://github.com/szjani/precore/pull/2 is merged.